### PR TITLE
Add image cropping overlay

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import Grid from './Grid';
 import ColorPalette from './ColorPalette';
 import { exportGridAsPng, findClosestDmcColor } from './utils';
 import { saveAs } from 'file-saver';
+import ImageCropper from './ImageCropper';
 
 function emptyGrid(size) {
   return Array.from({ length: size }, () => Array(size).fill(''));
@@ -24,6 +25,7 @@ export default function App() {
   const [grid, setGrid] = useState(emptyGrid(10));
   const [selectedColor, setSelectedColor] = useState('#000000');
   const [showGrid, setShowGrid] = useState(true);
+  const [croppingImage, setCroppingImage] = useState(null);
 
   // --- Responsive grid width ---
   const maxGridPx = 400; // The grid will always be this many px wide.
@@ -40,36 +42,32 @@ export default function App() {
     const reader = new FileReader();
     reader.onload = evt => {
       img.onload = () => {
-        // Always use the latest size
-        const canvas = document.createElement('canvas');
-        canvas.width = size;
-        canvas.height = size;
-        const ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0, size, size);
-
-        const imageData = ctx.getImageData(0, 0, size, size).data;
-        const newGrid = [];
-        for (let y = 0; y < size; y++) {
-          const row = [];
-          for (let x = 0; x < size; x++) {
-            const idx = (y * size + x) * 4;
-            const rgb = [
-              imageData[idx],
-              imageData[idx + 1],
-              imageData[idx + 2]
-            ];
-            row.push(findClosestDmcColor(rgb));
-          }
-          newGrid.push(row);
-        }
-        setGrid(newGrid);
-
-        // Reset file input so user can upload the same file again
-        if (fileInputRef.current) fileInputRef.current.value = "";
+        setCroppingImage(img);
       };
       img.src = evt.target.result;
     };
     reader.readAsDataURL(file);
+  };
+
+  const handleCropApply = imageData => {
+    const newGrid = [];
+    for (let y = 0; y < size; y++) {
+      const row = [];
+      for (let x = 0; x < size; x++) {
+        const idx = (y * size + x) * 4;
+        const rgb = [imageData[idx], imageData[idx + 1], imageData[idx + 2]];
+        row.push(findClosestDmcColor(rgb));
+      }
+      newGrid.push(row);
+    }
+    setGrid(newGrid);
+    setCroppingImage(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleCropCancel = () => {
+    setCroppingImage(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   // For loading JSON file
@@ -206,6 +204,15 @@ export default function App() {
         Image import maps to the closest DMC floss color. <br />
         Made with React. Enjoy!
       </small>
+      {croppingImage && (
+        <ImageCropper
+          img={croppingImage}
+          size={size}
+          maxGridPx={maxGridPx}
+          onCancel={handleCropCancel}
+          onApply={handleCropApply}
+        />
+      )}
     </div>
   );
 }

--- a/src/ImageCropper.js
+++ b/src/ImageCropper.js
@@ -1,0 +1,133 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+export default function ImageCropper({ img, size, maxGridPx = 400, onCancel, onApply }) {
+  const containerSize = maxGridPx;
+
+  const minScale = containerSize / Math.max(img.width, img.height);
+  const initialScale = containerSize / Math.min(img.width, img.height);
+
+  const [scale, setScale] = useState(initialScale);
+  const scaleRef = useRef(initialScale);
+  const [offset, setOffset] = useState({
+    x: (containerSize - img.width * initialScale) / 2,
+    y: (containerSize - img.height * initialScale) / 2
+  });
+
+  const dragRef = useRef(null);
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  const updateOffset = (x, y, s) => {
+    const w = img.width * s;
+    const h = img.height * s;
+    if (w <= containerSize) x = (containerSize - w) / 2;
+    else x = clamp(x, containerSize - w, 0);
+    if (h <= containerSize) y = (containerSize - h) / 2;
+    else y = clamp(y, containerSize - h, 0);
+    setOffset({ x, y });
+  };
+
+  const handleMouseDown = e => {
+    dragRef.current = { x: e.clientX, y: e.clientY, start: offset };
+  };
+
+  const handleMouseMove = e => {
+    if (!dragRef.current) return;
+    const dx = e.clientX - dragRef.current.x;
+    const dy = e.clientY - dragRef.current.y;
+    updateOffset(dragRef.current.start.x + dx, dragRef.current.start.y + dy, scale);
+  };
+
+  useEffect(() => {
+    const handleUp = () => {
+      dragRef.current = null;
+    };
+    window.addEventListener('mouseup', handleUp);
+    return () => window.removeEventListener('mouseup', handleUp);
+  }, []);
+
+  useEffect(() => {
+    const prevScale = scaleRef.current;
+    scaleRef.current = scale;
+    updateOffset(
+      offset.x + (img.width * prevScale - img.width * scale) / 2,
+      offset.y + (img.height * prevScale - img.height * scale) / 2,
+      scale
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scale]);
+
+  const handleApply = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    const srcX = Math.max(0, -offset.x / scale);
+    const srcY = Math.max(0, -offset.y / scale);
+    const srcW = containerSize / scale;
+    const srcH = containerSize / scale;
+    ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, size, size);
+    const imageData = ctx.getImageData(0, 0, size, size).data;
+    onApply(imageData);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000
+      }}
+    >
+      <div>
+        <div
+          style={{
+            position: 'relative',
+            width: containerSize,
+            height: containerSize,
+            overflow: 'hidden',
+            background: '#fff',
+            margin: '0 auto',
+            cursor: 'move'
+          }}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+        >
+          <img
+            src={img.src}
+            alt="crop"
+            style={{
+              position: 'absolute',
+              left: offset.x,
+              top: offset.y,
+              width: img.width * scale,
+              height: img.height * scale
+            }}
+          />
+        </div>
+        <div style={{ marginTop: 8, textAlign: 'center' }}>
+          <input
+            type="range"
+            min={minScale}
+            max={initialScale * 3}
+            step={0.1}
+            value={scale}
+            onChange={e => setScale(Number(e.target.value))}
+          />
+        </div>
+        <div style={{ marginTop: 8, textAlign: 'center' }}>
+          <button onClick={handleApply} style={{ marginRight: 8 }}>
+            Use Image
+          </button>
+          <button onClick={onCancel}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ImageCropper` component
- show overlay after importing an image so the user can zoom and position it before converting to stitches

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f789bd9d88324b7b0c0e1a35a47c5