### PR TITLE
Add Chakra UI components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
         "file-saver": "^2.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-scripts": "5.0.1"
+        "react-scripts": "5.0.1",
+        "@chakra-ui/react": "^2.7.1",
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "framer-motion": "^10.12.16"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "file-saver": "^2.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "@chakra-ui/react": "^2.7.1",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "framer-motion": "^10.12.16"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,15 @@ import ColorPalette from './ColorPalette';
 import { exportGridAsPng, findClosestDmcColor } from './utils';
 import { saveAs } from 'file-saver';
 import ImageCropper from './ImageCropper';
+import {
+  Box,
+  Flex,
+  Button,
+  Input,
+  Checkbox,
+  Heading,
+  Text
+} from '@chakra-ui/react';
 
 function emptyGrid(size) {
   return Array.from({ length: size }, () => Array(size).fill(''));
@@ -135,33 +144,37 @@ export default function App() {
   };
 
   return (
-    <div style={{ maxWidth: 600, margin: '30px auto', fontFamily: 'sans-serif', textAlign: 'center' }}>
-      <h2>🧵 Cross Stitch Pattern Creator</h2>
-      <div style={{ margin: '10px 0' }}>
+    <Box maxW="600px" m="30px auto" textAlign="center" fontFamily="sans-serif">
+      <Heading as="h2" size="md" mb={2}>
+        🧵 Cross Stitch Pattern Creator
+      </Heading>
+      <Flex my={2} align="center" justify="center">
         <label>
           Grid size:
-          <input
+          <Input
             type="number"
             min="2"
             max="40"
             value={size}
             onChange={handleSizeChange}
-            style={{ width: 50, marginLeft: 8 }}
+            w="50px"
+            ml={2}
+            display="inline-block"
           />
         </label>
-        <button onClick={handleNewGrid} style={{ marginLeft: 8 }}>Clear Grid</button>
-      </div>
+        <Button onClick={handleNewGrid} ml={2}>
+          Clear Grid
+        </Button>
+      </Flex>
       <ColorPalette selected={selectedColor} setSelected={setSelectedColor} />
-      <div>
-        <label>
-          <input
-            type="checkbox"
-            checked={showGrid}
-            onChange={() => setShowGrid(g => !g)}
-          />{' '}
+      <Box>
+        <Checkbox
+          isChecked={showGrid}
+          onChange={() => setShowGrid(g => !g)}
+        >
           Show Grid
-        </label>
-      </div>
+        </Checkbox>
+      </Box>
       <Grid
         grid={grid}
         setGrid={setGrid}
@@ -170,40 +183,37 @@ export default function App() {
         maxGridPx={maxGridPx}
       />
 
-      <div style={{ margin: '16px 0', display: 'flex', justifyContent: 'center', gap: 8, flexWrap: 'wrap' }}>
-        <button onClick={handleLocalSave}>Save to Browser</button>
-        <button onClick={handleLocalLoad}>Load from Browser</button>
-        <button onClick={handleExportJSON}>Export JSON</button>
-        <label style={{ cursor: 'pointer' }}>
-          <input
+      <Flex mt={4} mb={4} justify="center" gap={2} flexWrap="wrap">
+        <Button onClick={handleLocalSave}>Save to Browser</Button>
+        <Button onClick={handleLocalLoad}>Load from Browser</Button>
+        <Button onClick={handleExportJSON}>Export JSON</Button>
+        <Button as="label" cursor="pointer">
+          <Input
             type="file"
             accept="application/json"
-            style={{ display: 'none' }}
+            display="none"
             onChange={handleFile}
             ref={jsonInputRef}
           />
           Import JSON
-        </label>
-        <button onClick={handleExportPNG}>Export PNG</button>
-        {/* Image upload */}
-        <input
+        </Button>
+        <Button onClick={handleExportPNG}>Export PNG</Button>
+        <Input
           type="file"
           accept="image/*"
-          style={{ display: 'none' }}
+          display="none"
           ref={fileInputRef}
           onChange={e => handleImageUpload(e.target.files[0])}
         />
-        <button
-          onClick={() => fileInputRef.current && fileInputRef.current.click()}
-        >
+        <Button onClick={() => fileInputRef.current && fileInputRef.current.click()}>
           Import from Image
-        </button>
-      </div>
-      <small>
+        </Button>
+      </Flex>
+      <Text fontSize="sm">
         Designs are saved locally. PNG export uses your browser. <br />
         Image import maps to the closest DMC floss color. <br />
         Made with React. Enjoy!
-      </small>
+      </Text>
       {croppingImage && (
         <ImageCropper
           img={croppingImage}
@@ -213,6 +223,6 @@ export default function App() {
           onApply={handleCropApply}
         />
       )}
-    </div>
+    </Box>
   );
 }

--- a/src/ColorPalette.js
+++ b/src/ColorPalette.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Flex, Box, Text } from '@chakra-ui/react';
 
 export const DMC_COLORS = [
   { name: 'Salmon Very Light', code: '3713', hex: '#FFE2E2' },
@@ -459,25 +460,23 @@ export const DMC_COLORS = [
 
 export default function ColorPalette({ selected, setSelected }) {
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, margin: '10px 0', justifyContent: 'center' }}>
+    <Flex wrap="wrap" gap={2} my={2} justify="center">
       {DMC_COLORS.map(c => (
-        <div key={c.code} style={{ textAlign: 'center', fontSize: 11 }}>
-          <div
+        <Box key={c.code} textAlign="center" fontSize="11px">
+          <Box
             onClick={() => setSelected(c.hex)}
-            style={{
-              width: 24,
-              height: 24,
-              border: selected === c.hex ? '2px solid #333' : '1px solid #ccc',
-              background: c.hex,
-              borderRadius: 4,
-              cursor: 'pointer',
-              margin: '0 auto'
-            }}
+            w="24px"
+            h="24px"
+            border={selected === c.hex ? '2px solid #333' : '1px solid #ccc'}
+            bg={c.hex}
+            borderRadius="4px"
+            cursor="pointer"
+            m="0 auto"
             title={`${c.name} (${c.code})`}
           />
-          <div style={{ marginTop: 1 }}>{c.code}</div>
-        </div>
+          <Text mt={1}>{c.code}</Text>
+        </Box>
       ))}
-    </div>
+    </Flex>
   );
 }

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Box } from '@chakra-ui/react';
 import { DMC_COLORS } from './ColorPalette';
 
 function hexToDmc(hex) {
@@ -22,33 +23,29 @@ export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx
   };
 
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateRows: `repeat(${size}, ${cellSize}px)`,
-        gridTemplateColumns: `repeat(${size}, ${cellSize}px)`,
-        border: '2px solid #444',
-        width: cellSize * size,
-        margin: 'auto'
-      }}
+    <Box
+      display="grid"
+      gridTemplateRows={`repeat(${size}, ${cellSize}px)`}
+      gridTemplateColumns={`repeat(${size}, ${cellSize}px)`}
+      border="2px solid #444"
+      w={cellSize * size}
+      m="auto"
     >
       {grid.map((row, y) =>
         row.map((color, x) => (
-          <div
+          <Box
             key={`${y}-${x}`}
             onClick={() => handleCellClick(y, x)}
-            style={{
-              width: cellSize,
-              height: cellSize,
-              background: color || '#fff',
-              border: showGrid ? '1px solid #ccc' : 'none',
-              boxSizing: 'border-box',
-              cursor: 'pointer'
-            }}
+            w={cellSize}
+            h={cellSize}
+            bg={color || '#fff'}
+            border={showGrid ? '1px solid #ccc' : 'none'}
+            boxSizing="border-box"
+            cursor="pointer"
             title={hexToDmc(color) || `(${x + 1}, ${y + 1})`}
           />
         ))
       )}
-    </div>
+    </Box>
   );
 }

--- a/src/ImageCropper.js
+++ b/src/ImageCropper.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { Box, Button, Input } from '@chakra-ui/react';
 
 export default function ImageCropper({ img, size, maxGridPx = 400, onCancel, onApply }) {
   const containerSize = maxGridPx;
@@ -71,31 +72,27 @@ export default function ImageCropper({ img, size, maxGridPx = 400, onCancel, onA
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        background: 'rgba(0,0,0,0.7)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000
-      }}
+    <Box
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      bg="rgba(0,0,0,0.7)"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      zIndex={1000}
     >
-      <div>
-        <div
-          style={{
-            position: 'relative',
-            width: containerSize,
-            height: containerSize,
-            overflow: 'hidden',
-            background: '#fff',
-            margin: '0 auto',
-            cursor: 'move'
-          }}
+      <Box>
+        <Box
+          position="relative"
+          width={containerSize}
+          height={containerSize}
+          overflow="hidden"
+          bg="#fff"
+          m="0 auto"
+          cursor="move"
           onMouseDown={handleMouseDown}
           onMouseMove={handleMouseMove}
         >
@@ -110,9 +107,9 @@ export default function ImageCropper({ img, size, maxGridPx = 400, onCancel, onA
               height: img.height * scale
             }}
           />
-        </div>
-        <div style={{ marginTop: 8, textAlign: 'center' }}>
-          <input
+        </Box>
+        <Box mt={2} textAlign="center">
+          <Input
             type="range"
             min={minScale}
             max={initialScale * 3}
@@ -120,14 +117,14 @@ export default function ImageCropper({ img, size, maxGridPx = 400, onCancel, onA
             value={scale}
             onChange={e => setScale(Number(e.target.value))}
           />
-        </div>
-        <div style={{ marginTop: 8, textAlign: 'center' }}>
-          <button onClick={handleApply} style={{ marginRight: 8 }}>
+        </Box>
+        <Box mt={2} textAlign="center">
+          <Button onClick={handleApply} mr={2}>
             Use Image
-          </button>
-          <button onClick={onCancel}>Cancel</button>
-        </div>
-      </div>
-    </div>
+          </Button>
+          <Button onClick={onCancel}>Cancel</Button>
+        </Box>
+      </Box>
+    </Box>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <ChakraProvider>
+    <App />
+  </ChakraProvider>
+);


### PR DESCRIPTION
## Summary
- bring in Chakra UI libraries
- wrap the app in `ChakraProvider`
- reimplement the main layout with Chakra components
- update color palette, grid and image cropper to use Chakra primitives

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686007d53bac8324a70d45b74216ae2d