### PR TITLE
Fix wizard grid generation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,8 @@ import {
 import { saveAs } from 'file-saver';
 import ImportWizard from './ImportWizard';
 
-function emptyGrid(size) {
-  return Array.from({ length: size }, () => Array(size).fill(''));
+function emptyGrid(width, height = width) {
+  return Array.from({ length: height }, () => Array(width).fill(''));
 }
 
 function saveToLocal(name, grid) {
@@ -24,9 +24,13 @@ function loadFromLocal(name) {
   }
 }
 
+function getMaxDim(grid) {
+  return Math.max(grid.length, grid[0]?.length || 0);
+}
+
 export default function App() {
   const [size, setSize] = useState(100);
-  const [grid, setGrid] = useState(emptyGrid(100));
+  const [grid, setGrid] = useState(emptyGrid(100, 100));
   const [selectedColor, setSelectedColor] = useState('#000000');
   const [showGrid, setShowGrid] = useState(true);
   const [importImage, setImportImage] = useState(null);
@@ -69,7 +73,7 @@ export default function App() {
 
   const handleWizardComplete = newGrid => {
     setGrid(newGrid);
-    setSize(newGrid.length);
+    setSize(getMaxDim(newGrid));
     setImportImage(null);
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
@@ -88,7 +92,7 @@ export default function App() {
       try {
         const loaded = JSON.parse(evt.target.result);
         if (Array.isArray(loaded) && loaded.length > 0 && Array.isArray(loaded[0])) {
-          setSize(loaded.length);
+          setSize(getMaxDim(loaded));
           setGrid(loaded);
         } else {
           alert('Invalid file format.');
@@ -120,7 +124,7 @@ export default function App() {
   // New grid
   const handleNewGrid = () => {
     if (window.confirm('Clear current grid?')) {
-      setGrid(emptyGrid(size));
+      setGrid(emptyGrid(size, size));
     }
   };
 
@@ -128,7 +132,7 @@ export default function App() {
   const handleSizeChange = e => {
     const newSize = Number(e.target.value);
     setSize(newSize);
-    setGrid(emptyGrid(newSize));
+    setGrid(emptyGrid(newSize, newSize));
   };
 
   // Save/load to/from localStorage
@@ -136,7 +140,7 @@ export default function App() {
   const handleLocalLoad = () => {
     const loaded = loadFromLocal('cross_stitch');
     if (loaded) {
-      setSize(loaded.length);
+      setSize(getMaxDim(loaded));
       setGrid(loaded);
     } else {
       alert('No design found in local storage.');

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -9,8 +9,9 @@ function hexToDmc(hex) {
 }
 
 export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx = 400 }) {
-  const size = grid.length;
-  const cellSize = Math.floor(maxGridPx / size);
+  const rows = grid.length;
+  const cols = grid[0]?.length || 0;
+  const cellSize = Math.floor(maxGridPx / Math.max(rows, cols));
 
   const handleCellClick = (y, x) => {
     setGrid(prev =>
@@ -25,10 +26,10 @@ export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx
   return (
     <Box
       display="grid"
-      gridTemplateRows={`repeat(${size}, ${cellSize}px)`}
-      gridTemplateColumns={`repeat(${size}, ${cellSize}px)`}
+      gridTemplateRows={`repeat(${rows}, ${cellSize}px)`}
+      gridTemplateColumns={`repeat(${cols}, ${cellSize}px)`}
       border="2px solid #444"
-      w={cellSize * size}
+      w={cellSize * cols}
       m="auto"
     >
       {grid.map((row, y) =>

--- a/src/ImageCropper.js
+++ b/src/ImageCropper.js
@@ -30,6 +30,7 @@ export default function ImageCropper({ img, size, maxGridPx = 400, onCancel, onA
 
   const handleMouseDown = e => {
     dragRef.current = { x: e.clientX, y: e.clientY, start: offset };
+    window.addEventListener('mousemove', handleMouseMove);
   };
 
   const handleMouseMove = e => {
@@ -42,6 +43,7 @@ export default function ImageCropper({ img, size, maxGridPx = 400, onCancel, onA
   useEffect(() => {
     const handleUp = () => {
       dragRef.current = null;
+      window.removeEventListener('mousemove', handleMouseMove);
     };
     window.addEventListener('mouseup', handleUp);
     return () => window.removeEventListener('mouseup', handleUp);

--- a/src/ImportWizard.js
+++ b/src/ImportWizard.js
@@ -56,7 +56,8 @@ export default function ImportWizard({
   const [reduceTo, setReduceTo] = useState(1);
   const [maxColors, setMaxColors] = useState(1);
 
-  const gridSize = Math.round(Math.max(widthIn, heightIn) * fabricCount);
+  const gridWidth = Math.round(widthIn * fabricCount);
+  const gridHeight = Math.round(heightIn * fabricCount);
 
   const clamp = (v, min, max) => Math.min(Math.max(v, min), max);
 
@@ -72,6 +73,7 @@ export default function ImportWizard({
 
   const handleMouseDown = e => {
     dragRef.current = { x: e.clientX, y: e.clientY, start: offset };
+    window.addEventListener('mousemove', handleMouseMove);
   };
 
   const handleMouseMove = e => {
@@ -84,6 +86,7 @@ export default function ImportWizard({
   useEffect(() => {
     const handleUp = () => {
       dragRef.current = null;
+      window.removeEventListener('mousemove', handleMouseMove);
     };
     window.addEventListener('mouseup', handleUp);
     return () => window.removeEventListener('mouseup', handleUp);
@@ -101,21 +104,21 @@ export default function ImportWizard({
   }, [scale]);
 
   const generateGrid = () => {
-    const size = gridSize;
     const canvas = document.createElement('canvas');
-    canvas.width = canvas.height = size;
+    canvas.width = gridWidth;
+    canvas.height = gridHeight;
     const ctx = canvas.getContext('2d');
     const srcX = Math.max(0, -offset.x / scale);
     const srcY = Math.max(0, -offset.y / scale);
     const srcW = containerSize / scale;
     const srcH = containerSize / scale;
-    ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, size, size);
-    const data = ctx.getImageData(0, 0, size, size).data;
+    ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, gridWidth, gridHeight);
+    const data = ctx.getImageData(0, 0, gridWidth, gridHeight).data;
     const g = [];
-    for (let y = 0; y < size; y++) {
+    for (let y = 0; y < gridHeight; y++) {
       const row = [];
-      for (let x = 0; x < size; x++) {
-        const idx = (y * size + x) * 4;
+      for (let x = 0; x < gridWidth; x++) {
+        const idx = (y * gridWidth + x) * 4;
         const rgb = [data[idx], data[idx + 1], data[idx + 2]];
         row.push(findClosestDmcColor(rgb));
       }
@@ -260,7 +263,7 @@ export default function ImportWizard({
                 bottom={0}
                 style={{
                   backgroundImage: `linear-gradient(to right, rgba(0,0,0,0.3) 1px, transparent 1px), linear-gradient(to bottom, rgba(0,0,0,0.3) 1px, transparent 1px)`,
-                  backgroundSize: `${containerSize / gridSize}px ${containerSize / gridSize}px`
+                  backgroundSize: `${containerSize / gridWidth}px ${containerSize / gridHeight}px`
                 }}
               />
             </Box>

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,14 +78,16 @@ export function findClosestDmcColor(rgb) {
 
 // Export the grid as PNG (with optional grid overlay)
 export function exportGridAsPng(grid, cellSize, showGrid) {
-  const size = grid.length;
+  const rows = grid.length;
+  const cols = grid[0]?.length || 0;
   const canvas = document.createElement('canvas');
-  canvas.width = canvas.height = size * cellSize;
+  canvas.width = cols * cellSize;
+  canvas.height = rows * cellSize;
   const ctx = canvas.getContext('2d');
 
   // Draw cells
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
       ctx.fillStyle = grid[y][x] || '#fff';
       ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
     }
@@ -94,14 +96,16 @@ export function exportGridAsPng(grid, cellSize, showGrid) {
   // Optional grid overlay
   if (showGrid) {
     ctx.strokeStyle = '#888';
-    for (let i = 0; i <= size; i++) {
+    for (let i = 0; i <= cols; i++) {
       ctx.beginPath();
       ctx.moveTo(i * cellSize, 0);
-      ctx.lineTo(i * cellSize, size * cellSize);
+      ctx.lineTo(i * cellSize, rows * cellSize);
       ctx.stroke();
+    }
+    for (let j = 0; j <= rows; j++) {
       ctx.beginPath();
-      ctx.moveTo(0, i * cellSize);
-      ctx.lineTo(size * cellSize, i * cellSize);
+      ctx.moveTo(0, j * cellSize);
+      ctx.lineTo(cols * cellSize, j * cellSize);
       ctx.stroke();
     }
   }


### PR DESCRIPTION
## Summary
- support rectangular grids in app state and exports
- allow drag on cropper even when mouse leaves canvas
- generate grid using width and height in the wizard

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686028b109f483248e43afa58e5d7d72