### PR TITLE
Add collapsible color list to import wizard

### DIFF
--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import { Box, Collapse } from '@chakra-ui/react';
+
+export default function Collapsible({ label, children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Box textAlign="center" my={2}>
+      <Box
+        cursor="pointer"
+        fontWeight="bold"
+        onClick={() => setOpen(o => !o)}
+      >
+        {label}
+      </Box>
+      <Collapse in={open} animateOpacity>
+        <Box mt={2}>{children}</Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/src/ImportWizard.js
+++ b/src/ImportWizard.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import {
   Box,
   Button,
@@ -22,6 +22,8 @@ import {
 } from '@chakra-ui/react';
 import Grid from './Grid';
 import { findClosestDmcColor, getColorUsage, reduceColors } from './utils';
+import Collapsible from './Collapsible';
+import UsedColors from './UsedColors';
 
 export default function ImportWizard({
   img,
@@ -69,6 +71,7 @@ export default function ImportWizard({
   const [preview, setPreview] = useState(null);
   const [reduceTo, setReduceTo] = useState(1);
   const [maxColors, setMaxColors] = useState(1);
+  const colorUsage = useMemo(() => (preview ? getColorUsage(preview) : {}), [preview]);
 
   // Size preview scale so the entire design plus border fits inside the wizard
   const previewScale = Math.min(
@@ -400,7 +403,9 @@ export default function ImportWizard({
                 </SliderTrack>
                 <SliderThumb />
               </Slider>
-              <Text mt={1} textAlign='center'>{reduceTo} colors</Text>
+              <Collapsible label={<Text textAlign='center'>{reduceTo} colors</Text>}>
+                <UsedColors colors={Object.keys(colorUsage)} />
+              </Collapsible>
             </Box>
             <Flex justify='space-between' mt={4}>
               <Button onClick={prevStep}>Back</Button>

--- a/src/UsedColors.js
+++ b/src/UsedColors.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Flex, Box, Text } from '@chakra-ui/react';
+import { DMC_COLORS } from './ColorPalette';
+
+export default function UsedColors({ colors }) {
+  return (
+    <Flex wrap="wrap" gap={2} justify="center">
+      {colors.map(hex => {
+        const dmc = DMC_COLORS.find(c => c.hex.toLowerCase() === hex.toLowerCase());
+        return (
+          <Box key={hex} textAlign="center" fontSize="11px">
+            <Box
+              w="24px"
+              h="24px"
+              border="1px solid #ccc"
+              bg={hex}
+              borderRadius="4px"
+              m="0 auto"
+            />
+            <Text mt={1}>{dmc ? dmc.code : ''}</Text>
+          </Box>
+        );
+      })}
+    </Flex>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Collapsible` helper component
- create `UsedColors` list for displaying palette colors
- show a collapsible color list on the wizard color step

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603d5374d88324b9b6b25e9afa2f85