### PR TITLE
Add tooltips for colors in wizard

### DIFF
--- a/src/ImportWizard.js
+++ b/src/ImportWizard.js
@@ -404,7 +404,7 @@ export default function ImportWizard({
                 <SliderThumb />
               </Slider>
               <Collapsible label={<Text textAlign='center'>{reduceTo} colors</Text>}>
-                <UsedColors colors={Object.keys(colorUsage)} />
+                <UsedColors colors={Object.keys(colorUsage)} usage={colorUsage} />
               </Collapsible>
             </Box>
             <Flex justify='space-between' mt={4}>

--- a/src/UsedColors.js
+++ b/src/UsedColors.js
@@ -1,24 +1,30 @@
 import React from 'react';
-import { Flex, Box, Text } from '@chakra-ui/react';
+import { Flex, Box, Text, Tooltip } from '@chakra-ui/react';
 import { DMC_COLORS } from './ColorPalette';
 
-export default function UsedColors({ colors }) {
+export default function UsedColors({ colors, usage = {} }) {
   return (
     <Flex wrap="wrap" gap={2} justify="center">
       {colors.map(hex => {
         const dmc = DMC_COLORS.find(c => c.hex.toLowerCase() === hex.toLowerCase());
+        const count = usage[hex] || 0;
+        const label = dmc
+          ? `${dmc.name} (#${dmc.code})${count ? ` - ${count} stitches` : ''}`
+          : `${hex}${count ? ` - ${count} stitches` : ''}`;
         return (
-          <Box key={hex} textAlign="center" fontSize="11px">
-            <Box
-              w="24px"
-              h="24px"
-              border="1px solid #ccc"
-              bg={hex}
-              borderRadius="4px"
-              m="0 auto"
-            />
-            <Text mt={1}>{dmc ? dmc.code : ''}</Text>
-          </Box>
+          <Tooltip key={hex} label={label} hasArrow>
+            <Box textAlign="center" fontSize="11px">
+              <Box
+                w="24px"
+                h="24px"
+                border="1px solid #ccc"
+                bg={hex}
+                borderRadius="4px"
+                m="0 auto"
+              />
+              <Text mt={1}>{dmc ? dmc.code : ''}</Text>
+            </Box>
+          </Tooltip>
         );
       })}
     </Flex>


### PR DESCRIPTION
## Summary
- add Tooltip usage to show color names and counts in UsedColors
- pass color usage to UsedColors from ImportWizard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686041917d0c8324a68ab06eba9426d1