### PR TITLE
Add placeholder image options before upload

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,15 @@
 import React, { useState, useRef } from 'react';
-import { Box, Button } from '@chakra-ui/react';
+import { Box, Button, Image, SimpleGrid } from '@chakra-ui/react';
 import ImportWizard from './ImportWizard';
 import Header from './Header';
 import Footer from './Footer';
+import sample1 from './images/samples/sample1.svg';
+import sample2 from './images/samples/sample2.svg';
+import sample3 from './images/samples/sample3.svg';
 
 export default function App() {
   const [importImage, setImportImage] = useState(null);
+  const [showImageOptions, setShowImageOptions] = useState(false);
   const fileInputRef = useRef();
 
   const handleImageUpload = file => {
@@ -17,6 +21,7 @@ export default function App() {
       img.src = evt.target.result;
     };
     reader.readAsDataURL(file);
+    setShowImageOptions(false);
   };
 
   const handleWizardComplete = () => {
@@ -27,6 +32,18 @@ export default function App() {
   const handleWizardCancel = () => {
     setImportImage(null);
     if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleSelectSample = src => {
+    const img = new window.Image();
+    img.onload = () => setImportImage(img);
+    img.src = src;
+    setShowImageOptions(false);
+  };
+
+  const openFileDialog = () => {
+    setShowImageOptions(false);
+    if (fileInputRef.current) fileInputRef.current.click();
   };
 
   return (
@@ -48,12 +65,53 @@ export default function App() {
         <Button
           size="lg"
           colorScheme="teal"
-          onClick={() => fileInputRef.current && fileInputRef.current.click()}
+          onClick={() => setShowImageOptions(true)}
         >
           Try it out!
         </Button>
       </Box>
       <Footer />
+      {showImageOptions && (
+        <Box
+          position="fixed"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          bg="rgba(0,0,0,0.7)"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          zIndex={1000}
+        >
+          <Box bg="white" p={4} borderRadius="md">
+            <SimpleGrid columns={[1, 2]} spacing={4} minChildWidth="120px">
+              <Image
+                src={sample1}
+                alt="Sample 1"
+                cursor="pointer"
+                onClick={() => handleSelectSample(sample1)}
+              />
+              <Image
+                src={sample2}
+                alt="Sample 2"
+                cursor="pointer"
+                onClick={() => handleSelectSample(sample2)}
+              />
+              <Image
+                src={sample3}
+                alt="Sample 3"
+                cursor="pointer"
+                onClick={() => handleSelectSample(sample3)}
+              />
+              <Button onClick={openFileDialog}>Upload your own image</Button>
+            </SimpleGrid>
+            <Box textAlign="right" mt={4}>
+              <Button onClick={() => setShowImageOptions(false)}>Cancel</Button>
+            </Box>
+          </Box>
+        </Box>
+      )}
       {importImage && (
         <ImportWizard
           img={importImage}

--- a/src/images/samples/sample1.svg
+++ b/src/images/samples/sample1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300">
+  <rect width="300" height="300" fill="#d9e8ff"/>
+  <text x="150" y="160" font-size="40" fill="#3366ff" text-anchor="middle" font-family="Arial, sans-serif">Sample 1</text>
+</svg>

--- a/src/images/samples/sample2.svg
+++ b/src/images/samples/sample2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300">
+  <rect width="300" height="300" fill="#ffe6e6"/>
+  <text x="150" y="160" font-size="40" fill="#ff3333" text-anchor="middle" font-family="Arial, sans-serif">Sample 2</text>
+</svg>

--- a/src/images/samples/sample3.svg
+++ b/src/images/samples/sample3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300">
+  <rect width="300" height="300" fill="#e6ffe6"/>
+  <text x="150" y="160" font-size="40" fill="#009900" text-anchor="middle" font-family="Arial, sans-serif">Sample 3</text>
+</svg>


### PR DESCRIPTION
## Summary
- include sample images for quick testing
- show an overlay with 3 sample images and an "Upload your own" button before launching the wizard

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686059a15e08832496697490cc0e4776