### PR TITLE
Update number input formatting

### DIFF
--- a/src/ImportWizard.js
+++ b/src/ImportWizard.js
@@ -30,6 +30,7 @@ import Grid from './Grid';
 import { findClosestDmcColor, getColorUsage, reduceColors } from './utils';
 import Collapsible from './Collapsible';
 import UsedColors from './UsedColors';
+import NumberInputRoot from './NumberInputRoot';
 
 export default function ImportWizard({
   img,
@@ -364,19 +365,24 @@ export default function ImportWizard({
                   transition: 'transform 0.2s ease-in-out'
                 }
               }}>
-                <InputGroup>
-                  <NumberInput
-                    value={heightIn}
-                    onChange={(_, v) => setHeightIn(v)}
-                    min={2}
-                    max={10}
-                    width='full'
-                  >
-                    <NumberInputField
-                      placeholder=' '
-                      data-has-value={heightIn > 0}
-                    />
-                  </NumberInput>
+                  <InputGroup>
+                    <NumberInputRoot
+                      value={heightIn}
+                      onChange={(_, v) => setHeightIn(v)}
+                      min={2}
+                      max={10}
+                      width='full'
+                      formatOptions={{
+                        style: 'unit',
+                        unit: 'inch',
+                        unitDisplay: 'long'
+                      }}
+                    >
+                      <NumberInputField
+                        placeholder=' '
+                        data-has-value={heightIn > 0}
+                      />
+                    </NumberInputRoot>
                   <InputRightAddon>Inches</InputRightAddon>
                 </InputGroup>
                 <FormLabel>Height</FormLabel>

--- a/src/NumberInputRoot.js
+++ b/src/NumberInputRoot.js
@@ -1,0 +1,20 @@
+import React, { useMemo } from 'react';
+import { NumberInput } from '@chakra-ui/react';
+
+export default function NumberInputRoot({ formatOptions, ...props }) {
+  const format = useMemo(() => {
+    if (!formatOptions) return value => value;
+    const formatter = new Intl.NumberFormat(undefined, formatOptions);
+    return value => {
+      if (value === null || value === undefined || value === '') return '';
+      return formatter.format(value);
+    };
+  }, [formatOptions]);
+
+  const parse = useMemo(() => {
+    if (!formatOptions) return value => value;
+    return value => value.replace(/[^0-9.+-]/g, '');
+  }, [formatOptions]);
+
+  return <NumberInput format={format} parse={parse} {...props} />;
+}


### PR DESCRIPTION
## Summary
- support formatting via a custom `NumberInputRoot`
- use the new component for the height field

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860bade0c348324b2de7c5f9938fa66