### PR TITLE
Fix missing border lines in size preview

### DIFF
--- a/src/ImportWizard.js
+++ b/src/ImportWizard.js
@@ -387,6 +387,16 @@ export default function ImportWizard({
                     backgroundSize: '100% 100%'
                   }}
                 />
+                <Box
+                  pointerEvents='none'
+                  position='absolute'
+                  left={0}
+                  top={0}
+                  right={0}
+                  bottom={0}
+                  borderRight='2px solid rgba(0,0,0,1)'
+                  borderBottom='2px solid rgba(0,0,0,1)'
+                />
               </Box>
             </Box>
             <Flex justify='space-between' mt={4}>


### PR DESCRIPTION
## Summary
- increase bottom/right border to 2px solid black so preview edges remain visible

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b2e83f9483249a1c918760cd9a5d