### PR TITLE
Add floss usage info

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -198,7 +198,11 @@ export default function App() {
               <Box mb={2}>
                 <strong>Colors</strong>
               </Box>
-              <UsedColors colors={pattern.colors} usage={pattern.colorUsage} />
+              <UsedColors
+                colors={pattern.colors}
+                usage={pattern.colorUsage}
+                showSkeins
+              />
             </DrawerBody>
           </DrawerContent>
         </Drawer>

--- a/src/UsedColors.js
+++ b/src/UsedColors.js
@@ -2,15 +2,18 @@ import React from 'react';
 import { Flex, Box, Text, Tooltip } from '@chakra-ui/react';
 import { DMC_COLORS } from './ColorPalette';
 
-export default function UsedColors({ colors, usage = {} }) {
+export default function UsedColors({ colors, usage = {}, showSkeins = false }) {
   return (
     <Flex wrap="wrap" gap={2} justify="center">
       {colors.map(hex => {
         const dmc = DMC_COLORS.find(c => c.hex.toLowerCase() === hex.toLowerCase());
         const count = usage[hex] || 0;
+        const skeins = showSkeins && count
+          ? ` - ${(count / 1800).toFixed(2)} skeins`
+          : '';
         const label = dmc
-          ? `${dmc.name} (#${dmc.code})${count ? ` - ${count} stitches` : ''}`
-          : `${hex}${count ? ` - ${count} stitches` : ''}`;
+          ? `${dmc.name} (#${dmc.code})${count ? ` - ${count} stitches` : ''}${skeins}`
+          : `${hex}${count ? ` - ${count} stitches` : ''}${skeins}`;
         return (
           <Tooltip key={hex} label={label} hasArrow>
             <Box textAlign="center" fontSize="11px">


### PR DESCRIPTION
## Summary
- show floss requirements for each color in the pattern details drawer

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860c7943ab48324aff5a560b45f1448