### PR TITLE
Add magnifier for final grid

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ import {
   FormControl,
   FormLabel
 } from '@chakra-ui/react';
-import Grid from './Grid';
+import GridMagnifier from './GridMagnifier';
 import UsedColors from './UsedColors';
 import ImportWizard from './ImportWizard';
 import Header from './Header';
@@ -119,10 +119,8 @@ export default function App() {
         )}
         {pattern && (
           <>
-            <Grid
+            <GridMagnifier
               grid={pattern.grid}
-              setGrid={() => {}}
-              selectedColor={null}
               showGrid={showGridLines}
               maxGridPx={500}
             />

--- a/src/GridMagnifier.js
+++ b/src/GridMagnifier.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { Box } from '@chakra-ui/react';
+import Grid from './Grid';
+
+export default function GridMagnifier({
+  grid,
+  showGrid,
+  maxGridPx = 500,
+  zoom = 3,
+  lensSize = 150
+}) {
+  const [pos, setPos] = useState(null);
+
+  const handleMove = e => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setPos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+  };
+
+  const handleLeave = () => setPos(null);
+
+  const lensStyle = pos
+    ? {
+        position: 'absolute',
+        pointerEvents: 'none',
+        left: pos.x - lensSize / 2,
+        top: pos.y - lensSize / 2,
+        width: lensSize,
+        height: lensSize,
+        borderRadius: '50%',
+        overflow: 'hidden',
+        border: '2px solid #333',
+        boxShadow: '0 0 4px rgba(0,0,0,0.5)'
+      }
+    : { display: 'none' };
+
+  const translateX = pos ? -pos.x * (zoom - 1) : 0;
+  const translateY = pos ? -pos.y * (zoom - 1) : 0;
+  const zoomStyle = {
+    transform: `translate(${translateX}px, ${translateY}px) scale(${zoom})`,
+    transformOrigin: '0 0'
+  };
+
+  return (
+    <Box position="relative" width="fit-content" onMouseMove={handleMove} onMouseLeave={handleLeave}>
+      <Grid
+        grid={grid}
+        setGrid={() => {}}
+        selectedColor={null}
+        showGrid={showGrid}
+        maxGridPx={maxGridPx}
+      />
+      <Box style={lensStyle}>
+        <Box style={zoomStyle}>
+          <Grid
+            grid={grid}
+            setGrid={() => {}}
+            selectedColor={null}
+            showGrid={showGrid}
+            maxGridPx={maxGridPx}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GridMagnifier` component that displays a circular magnifying lens
- use `GridMagnifier` in `App` so users can magnify the final grid image

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860cdd5f09c8324a761af70f89ce614