### PR TITLE
Add cell/color highlighting in deep dive

### DIFF
--- a/src/DeepDive.js
+++ b/src/DeepDive.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Flex, Button } from '@chakra-ui/react';
 import UsedColors from './UsedColors';
 import { getColorUsage } from './utils';
@@ -30,6 +30,8 @@ export default function DeepDive() {
 
   const [hover, setHover] = useState(null);
   const [selected, setSelected] = useState(null);
+  const [focusedCell, setFocusedCell] = useState(null);
+  const [focusedColor, setFocusedColor] = useState(null);
 
   const overlays = [];
   for (let y = 0; y < inchRows; y++) {
@@ -57,6 +59,11 @@ export default function DeepDive() {
   }
 
   const active = selected || hover;
+
+  useEffect(() => {
+    setFocusedCell(null);
+    setFocusedColor(null);
+  }, [active]);
 
   const subGrid = active
     ? grid
@@ -104,11 +111,22 @@ export default function DeepDive() {
               selectedColor={null}
               showGrid={true}
               maxGridPx={300}
+              activeCell={focusedCell}
+              activeColor={focusedColor}
+              onCellClick={(y, x, color) => {
+                setFocusedCell({ y, x });
+                setFocusedColor(color);
+              }}
             />
             <Box mt={2}>
               <UsedColors
                 colors={Object.keys(colorUsage)}
                 usage={colorUsage}
+                activeColor={focusedColor}
+                onColorClick={color => {
+                  setFocusedCell(null);
+                  setFocusedColor(color);
+                }}
               />
             </Box>
           </Box>

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -8,20 +8,32 @@ function hexToDmc(hex) {
   return found ? `${found.name} (#${found.code})` : null;
 }
 
-export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx = 400 }) {
+export default function Grid({
+  grid,
+  setGrid,
+  selectedColor,
+  showGrid,
+  maxGridPx = 400,
+  activeCell = null,
+  activeColor = null,
+  onCellClick = null
+}) {
   const rows = grid.length;
   const cols = grid[0]?.length || 0;
   const BORDER = 4; // total px for the 2px border around the grid
   const cellSize = Math.floor((maxGridPx - BORDER) / Math.max(rows, cols));
 
   const handleCellClick = (y, x) => {
-    setGrid(prev =>
-      prev.map((row, rowIdx) =>
-        rowIdx === y
-          ? row.map((cell, colIdx) => (colIdx === x ? selectedColor : cell))
-          : row
-      )
-    );
+    if (onCellClick) onCellClick(y, x, grid[y][x]);
+    if (setGrid && selectedColor !== undefined && selectedColor !== null) {
+      setGrid(prev =>
+        prev.map((row, rowIdx) =>
+          rowIdx === y
+            ? row.map((cell, colIdx) => (colIdx === x ? selectedColor : cell))
+            : row
+        )
+      );
+    }
   };
 
   return (
@@ -40,6 +52,11 @@ export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx
       {grid.map((row, y) =>
         row.map((color, x) => {
           const dmcLabel = hexToDmc(color) || `(${x + 1}, ${y + 1})`;
+          const dimmed = activeCell
+            ? !(activeCell.y === y && activeCell.x === x)
+            : activeColor
+            ? color !== activeColor
+            : false;
           return (
             <Tooltip key={`${y}-${x}`} label={dmcLabel} hasArrow>
               <Box
@@ -50,6 +67,7 @@ export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx
                 border={showGrid ? '1px solid #ccc' : 'none'}
                 boxSizing="border-box"
                 cursor="pointer"
+                opacity={dimmed ? 0.3 : 1}
               />
             </Tooltip>
           );

--- a/src/UsedColors.js
+++ b/src/UsedColors.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { Flex, Box, Text, Tooltip } from '@chakra-ui/react';
 import { DMC_COLORS } from './ColorPalette';
 
-export default function UsedColors({ colors, usage = {}, showSkeins = false }) {
+export default function UsedColors({
+  colors,
+  usage = {},
+  showSkeins = false,
+  activeColor = null,
+  onColorClick = null
+}) {
   return (
     <Flex wrap="wrap" gap={2} justify="center">
       {colors.map(hex => {
@@ -14,9 +20,10 @@ export default function UsedColors({ colors, usage = {}, showSkeins = false }) {
         const label = dmc
           ? `${dmc.name} (#${dmc.code})${count ? ` - ${count} stitches` : ''}${skeins}`
           : `${hex}${count ? ` - ${count} stitches` : ''}${skeins}`;
+        const dimmed = activeColor && activeColor.toLowerCase() !== hex.toLowerCase();
         return (
           <Tooltip key={hex} label={label} hasArrow>
-            <Box textAlign="center" fontSize="11px">
+            <Box textAlign="center" fontSize="11px" opacity={dimmed ? 0.3 : 1} cursor={onColorClick ? 'pointer' : 'default'} onClick={() => onColorClick && onColorClick(hex)}>
               <Box
                 w="24px"
                 h="24px"


### PR DESCRIPTION
## Summary
- allow `Grid` to dim cells via `activeCell` and `activeColor`
- make `UsedColors` selectable and dim non-selected colors
- enable selecting cells or colors on the Deep Dive page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686168d242a08324904f2205c32fe3e4