### PR TITLE
Add section completion toggle

### DIFF
--- a/src/DeepDive.js
+++ b/src/DeepDive.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Flex, Button } from '@chakra-ui/react';
 import UsedColors from './UsedColors';
 import { getColorUsage } from './utils';
@@ -30,6 +30,11 @@ export default function DeepDive() {
 
   const [hover, setHover] = useState(null);
   const [selected, setSelected] = useState(null);
+  const [sectionComplete, setSectionComplete] = useState(false);
+
+  useEffect(() => {
+    setSectionComplete(false);
+  }, [selected?.x, selected?.y]);
 
   const overlays = [];
   for (let y = 0; y < inchRows; y++) {
@@ -104,6 +109,7 @@ export default function DeepDive() {
               selectedColor={null}
               showGrid={true}
               maxGridPx={300}
+              markX={sectionComplete}
             />
             <Box mt={2}>
               <UsedColors
@@ -111,6 +117,14 @@ export default function DeepDive() {
                 usage={colorUsage}
               />
             </Box>
+            <Button
+              mt={2}
+              width="100%"
+              colorScheme="teal"
+              onClick={() => setSectionComplete(prev => !prev)}
+            >
+              {sectionComplete ? 'Revisit Section' : 'Section Complete'}
+            </Button>
           </Box>
         )}
       </Flex>

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Tooltip } from '@chakra-ui/react';
 import { DMC_COLORS } from './ColorPalette';
+import { slightShade } from './utils';
 
 function hexToDmc(hex) {
   if (!hex) return null;
@@ -8,7 +9,7 @@ function hexToDmc(hex) {
   return found ? `${found.name} (#${found.code})` : null;
 }
 
-export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx = 400 }) {
+export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx = 400, markX = false }) {
   const rows = grid.length;
   const cols = grid[0]?.length || 0;
   const BORDER = 4; // total px for the 2px border around the grid
@@ -50,7 +51,28 @@ export default function Grid({ grid, setGrid, selectedColor, showGrid, maxGridPx
                 border={showGrid ? '1px solid #ccc' : 'none'}
                 boxSizing="border-box"
                 cursor="pointer"
-              />
+                position="relative"
+              >
+                {markX && color && (
+                  <Box
+                    position="absolute"
+                    top={0}
+                    left={0}
+                    width="100%"
+                    height="100%"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    pointerEvents="none"
+                    color={slightShade(color)}
+                    fontSize={`${cellSize * 0.8}px`}
+                    fontWeight="bold"
+                    lineHeight="1"
+                  >
+                    X
+                  </Box>
+                )}
+              </Box>
             </Tooltip>
           );
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,3 +112,18 @@ export function exportGridAsPng(grid, cellSize, showGrid) {
 
   return canvas.toDataURL('image/png');
 }
+
+// Return a shade slightly lighter or darker than the given color
+export function slightShade(hex, amount = 40) {
+  const [r, g, b] = hexToRgb(hex);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  const adj = brightness > 128 ? -amount : amount;
+  const clamp = v => Math.max(0, Math.min(255, v));
+  const toHex = v => v.toString(16).padStart(2, '0');
+  return (
+    '#' +
+    toHex(clamp(r + adj)) +
+    toHex(clamp(g + adj)) +
+    toHex(clamp(b + adj))
+  );
+}


### PR DESCRIPTION
## Summary
- add `slightShade` helper to compute related shade
- support optional `markX` overlay in `Grid`
- enable section completion marker in `DeepDive`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686169fd2c6c8324b6b1b8931ea7da9d