### PR TITLE
Improve deep dive color highlighting

### DIFF
--- a/src/DeepDive.js
+++ b/src/DeepDive.js
@@ -79,7 +79,7 @@ export default function DeepDive() {
         Back
       </Button>
       <Flex gap={4} flexDir={{ base: 'column', md: 'row' }} align="flex-start">
-        <Box position="relative" width={gridWidth} height={gridHeight} flexShrink={0}>
+        <Box position="relative" width={gridWidth} height={gridHeight} flexShrink={0} overflow="hidden">
           <Grid
             grid={grid}
             setGrid={() => {}}
@@ -114,7 +114,7 @@ export default function DeepDive() {
               activeCell={focusedCell}
               activeColor={focusedColor}
               onCellClick={(y, x, color) => {
-                setFocusedCell({ y, x });
+                setFocusedCell(null);
                 setFocusedColor(color);
               }}
             />


### PR DESCRIPTION
## Summary
- highlight all cells of the same color when clicking a cell in Deep Dive view
- keep magnified grid free from dimmed overlay

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68616c41b7d483248b71085ba96877bd