### PR TITLE
Fix footer position on deep dive page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -103,7 +103,9 @@ export default function App() {
     return (
       <Box minH="100vh" display="flex" flexDirection="column">
         <Header />
-        <DeepDive />
+        <Box flex="1">
+          <DeepDive />
+        </Box>
         <Footer />
       </Box>
     );


### PR DESCRIPTION
## Summary
- ensure Deep Dive page stretches to fill remaining vertical space

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68617c8646e48324bf24a99c6e145c9e