### PR TITLE
Fix DeepDive hover overlay alignment

### DIFF
--- a/src/DeepDive.js
+++ b/src/DeepDive.js
@@ -25,6 +25,7 @@ export default function DeepDive() {
   const cellSize = Math.floor((maxGridPx - BORDER) / Math.max(rows, cols));
   const gridWidth = cellSize * cols + BORDER;
   const gridHeight = cellSize * rows + BORDER;
+  const borderOffset = BORDER / 2; // offset for the 2px grid border
   const inchPx = cellSize * fabricCount;
   const inchCols = Math.ceil(cols / fabricCount);
   const inchRows = Math.ceil(rows / fabricCount);
@@ -120,15 +121,21 @@ export default function DeepDive() {
             maxGridPx={maxGridPx}
             completedCells={completedCells}
           />
-          <Box position="absolute" top={0} left={0} right={0} bottom={0}>
+          <Box
+            position="absolute"
+            top={borderOffset}
+            left={borderOffset}
+            right={borderOffset}
+            bottom={borderOffset}
+          >
             {overlays}
           </Box>
           {active && (
             <Box
               pointerEvents="none"
               position="absolute"
-              left={active.x * inchPx}
-              top={active.y * inchPx}
+              left={borderOffset + active.x * inchPx}
+              top={borderOffset + active.y * inchPx}
               width={active.w}
               height={active.h}
               boxShadow="0 0 0 9999px rgba(0,0,0,0.5)"


### PR DESCRIPTION
## Summary
- fix overlay offsets in DeepDive page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861b217d6b88324973b5a4e431b3df8