### PR TITLE
Improve grid performance by removing heavy tooltips

### DIFF
--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Tooltip } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { DMC_COLORS } from './ColorPalette';
 import { overlayShade } from './utils';
 
@@ -64,25 +64,25 @@ export default function Grid({
           const isComplete =
             markComplete || (completedCells && completedCells.has(cellKey));
           return (
-            <Tooltip key={`${y}-${x}`} label={dmcLabel} hasArrow>
-              <Box
-                onClick={() => handleCellClick(y, x)}
-                w={cellSize}
-                h={cellSize}
-                bg={color || '#fff'}
-                border={showGrid ? '1px solid #ccc' : 'none'}
-                boxSizing="border-box"
-                cursor="pointer"
-                opacity={dimmed ? 0.3 : 1}
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                color={isComplete ? overlayShade(color || '#fff') : 'inherit'}
-                fontWeight={isComplete ? 'bold' : 'normal'}
-              >
-                {isComplete ? 'X' : null}
-              </Box>
-            </Tooltip>
+            <Box
+              key={`${y}-${x}`}
+              onClick={() => handleCellClick(y, x)}
+              w={cellSize}
+              h={cellSize}
+              bg={color || '#fff'}
+              border={showGrid ? '1px solid #ccc' : 'none'}
+              boxSizing="border-box"
+              cursor="pointer"
+              opacity={dimmed ? 0.3 : 1}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              color={isComplete ? overlayShade(color || '#fff') : 'inherit'}
+              fontWeight={isComplete ? 'bold' : 'normal'}
+              title={dmcLabel}
+            >
+              {isComplete ? 'X' : null}
+            </Box>
           );
         })
       )}


### PR DESCRIPTION
## Summary
- optimize grid hover performance by replacing Chakra `Tooltip` with a native `title` attribute

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861b795dc58832494a51e5c64794c6c